### PR TITLE
Fix case with no resources specified

### DIFF
--- a/add-permissions.js
+++ b/add-permissions.js
@@ -20,7 +20,7 @@ module.exports = class AwsAddLambdaAccountPermissions {
     if (typeof service.functions !== 'object') {
       return;
     }
-    const resources = service.resources || {};
+    const resources = service.resources = service.resources || {};
     if (!resources.Resources) {
       resources.Resources = {};
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-account-access",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
This is a fix for case when there is no resources defined in serverless.yml. The problem was that during this assignment `const resources = service.resources || {};`, `resources` variable was getting `{}` as a value, but not reference to `service.resources`.