### PR TITLE
Use ARNs as principals

### DIFF
--- a/add-permissions.js
+++ b/add-permissions.js
@@ -27,7 +27,8 @@ module.exports = class AwsAddLambdaAccountPermissions {
     Object.keys(service.functions).forEach(functionName => {
       const functionLogicalId = this.provider.naming
         .getLambdaLogicalId(functionName);
-      resources.Resources[`${functionLogicalId}PermitInvokeFromAccount${account}`] = {
+      const resourceName = account.replace(/[_\W]/g, '')
+      resources.Resources[`${functionLogicalId}PermitInvokeFromAccount${resourceName}`] = {
         Type: 'AWS::Lambda::Permission',
         Properties: {
           Action: 'lambda:InvokeFunction',

--- a/add-permissions.js
+++ b/add-permissions.js
@@ -27,8 +27,8 @@ module.exports = class AwsAddLambdaAccountPermissions {
     Object.keys(service.functions).forEach(functionName => {
       const functionLogicalId = this.provider.naming
         .getLambdaLogicalId(functionName);
-      const resourceName = account.replace(/[_\W]/g, '')
-      resources.Resources[`${functionLogicalId}PermitInvokeFromAccount${resourceName}`] = {
+      const resourceName = account.replace(/\b\w/g, l => l.toUpperCase()).replace(/[_\W]+/g, "");
+      resources.Resources[`${functionLogicalId}PermitInvokeFrom${resourceName}`] = {
         Type: 'AWS::Lambda::Permission',
         Properties: {
           Action: 'lambda:InvokeFunction',


### PR DESCRIPTION
This gives the ability to grant access to full ARNs in addition to account numbers. You just put the ARN where you would put the account number:

```
provider:
  permitAccounts: 000001,arn:aws:iam::000002:user/alice,000003
```