### PR TITLE
Corrected documentation, closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ plugins:
   - serverless-plugin-lambda-account-access
 
 provider:
-  allowAccounts: # can be defined as a single value or an array
+  allowAccess: # can be defined as a single value or an array
     - 111111111111 # principal as accountId
     - 'arn:aws:iam::222222222222:root' # principal as ARN
 


### PR DESCRIPTION
Corrected documentation in Readme, example should use allowAccess instead of allowAccounts.