### PR TITLE
Define schemas to fix serverless warnings

### DIFF
--- a/add-permissions.js
+++ b/add-permissions.js
@@ -1,7 +1,5 @@
  'use strict';
 
-const semver = require('semver');
-
 const STRING_OR_STRING_ARRAY = {
   anyOf: [
     {
@@ -71,9 +69,6 @@ const ACCESS_SCHEMA = {
 
 module.exports = class AwsAddLambdaAccountPermissions {
   constructor(serverless, options) {
-    if (!semver.satisfies(serverless.version, '>= 1.12')) {
-      throw new Error('serverless-plugin-lambda-account-access requires serverless 1.12 or higher!');
-    }
     this.serverless = serverless;
     this.options = options;
     this.provider = this.serverless.getProvider('aws');

--- a/add-permissions.js
+++ b/add-permissions.js
@@ -2,6 +2,73 @@
 
 const semver = require('semver');
 
+const STRING_OR_STRING_ARRAY = {
+  anyOf: [
+    {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    },
+    {
+      type: 'string'
+    }
+  ]
+};
+
+const ROLE_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    principals: STRING_OR_STRING_ARRAY,
+    allowTagSession: { type: 'boolean' },
+    maxSessionDuration: {
+      type: 'integer',
+      minimum: 3600,
+      maximum: 43200,
+    },
+  },
+  required: ['name', 'principals'],
+  additionalProperties: false,
+};
+
+const ACCESS_SCHEMA = {
+  type: 'object',
+  properties: {
+    groups: {
+      type: 'object',
+      patternProperties: {
+        '.+': {
+          type: 'object',
+          properties: {
+            role: {
+              anyOf: [
+                {
+                  type: 'array',
+                  items: ROLE_SCHEMA
+                },
+                ROLE_SCHEMA,
+              ]
+            },
+            policy: {
+              type: 'object',
+              properties: {
+                principals: STRING_OR_STRING_ARRAY,
+              },
+              required: ['principals']
+            },
+          },
+          minProperties: 1,
+          additionalProperties: false,
+        }
+      },
+      minProperties: 1,
+    },
+  },
+  required: ['groups'],
+  additionalProperties: false,
+};
+
 module.exports = class AwsAddLambdaAccountPermissions {
   constructor(serverless, options) {
     if (!semver.satisfies(serverless.version, '>= 1.12')) {
@@ -13,6 +80,20 @@ module.exports = class AwsAddLambdaAccountPermissions {
     this.hooks = {
       'package:createDeploymentArtifacts': () => this.beforeDeploy(),
     };
+
+    serverless.configSchemaHandler.defineFunctionProperties('aws', {
+      properties: {
+        allowAccess: STRING_OR_STRING_ARRAY,
+      },
+    });
+
+    serverless.configSchemaHandler.defineProvider('aws', {
+      provider: {
+        properties: {
+          access: ACCESS_SCHEMA,
+        },
+      }
+    });
   }
 
   addPermissions(accessConfig) {
@@ -27,12 +108,7 @@ module.exports = class AwsAddLambdaAccountPermissions {
 
       if (functions.length !== 0) {
         if (policy) {
-          const { principals } = policy;
-          if (!principals) {
-            throw new Error(`Group "${groupName}" does not have policy principals configured`);
-          }
-
-          [].concat(principals).forEach(principal => {
+          [].concat(policy.principals).forEach(principal => {
             const {
               principal: normalizedPrincipal,
               principalName
@@ -67,14 +143,6 @@ module.exports = class AwsAddLambdaAccountPermissions {
 
         if (role) {
           [].concat(role).forEach(({ allowTagSession = false, maxSessionDuration = 3600, name, principals }) => {
-            if (!name) {
-              throw new Error(`Group "${groupName}" does not have role name configured`);
-            }
-
-            if (!principals) {
-              throw new Error(`Role "${name}" in the "${groupName}" group does not have principals configured`);
-            }
-
             const resourceName = `LambdaAccessRole${this.normalizeName(name)}`;
             if (resources.Resources[resourceName]) {
               throw new Error(`Roles must have unique names [${name}]`);
@@ -137,10 +205,6 @@ module.exports = class AwsAddLambdaAccountPermissions {
     }
 
     const { groups } = access;
-    if (!groups) {
-      throw new Error('Access configuration must have groups defined');
-    }
-
     const accessConfig = this.compileAccessConfig(groups, functions);
 
     this.addPermissions(accessConfig);

--- a/add-permissions.js
+++ b/add-permissions.js
@@ -81,19 +81,25 @@ module.exports = class AwsAddLambdaAccountPermissions {
       'package:createDeploymentArtifacts': () => this.beforeDeploy(),
     };
 
-    serverless.configSchemaHandler.defineFunctionProperties('aws', {
-      properties: {
-        allowAccess: STRING_OR_STRING_ARRAY,
-      },
-    });
-
-    serverless.configSchemaHandler.defineProvider('aws', {
-      provider: {
-        properties: {
-          access: ACCESS_SCHEMA,
-        },
+    if (serverless.configSchemaHandler) {
+      if (serverless.configSchemaHandler.defineFunctionProperties) {
+        serverless.configSchemaHandler.defineFunctionProperties('aws', {
+          properties: {
+            allowAccess: STRING_OR_STRING_ARRAY,
+          },
+        });
       }
-    });
+
+      if (serverless.configSchemaHandler.defineProvider) {
+        serverless.configSchemaHandler.defineProvider('aws', {
+          provider: {
+            properties: {
+              access: ACCESS_SCHEMA,
+            },
+          }
+        });
+      }
+    }
   }
 
   addPermissions(accessConfig) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-account-access",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2361,7 +2361,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-lambda-account-access",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "engines": {
     "node": ">=8.10"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,5 @@
     "nyc": "^15.1.0",
     "sinon": "^7.5.0"
   },
-  "dependencies": {
-    "semver": "^6.3.0"
-  }
+  "dependencies": {}
 }

--- a/test/add-permissions-tests.js
+++ b/test/add-permissions-tests.js
@@ -102,20 +102,6 @@ describe('serverless-plugin-lambda-account-access', function() {
         .that.is.undefined;
     });
 
-    it('should throw when access config does not have groups', function() {
-      const instance = createTestInstance({
-        provider: {
-          access: {}
-        },
-        functions: {
-          function1: {}
-        }
-      });
-
-      expect(() => instance.beforeDeploy())
-        .to.throw('Access configuration must have groups defined');
-    });
-
     it('should throw when function references access group that does not exist', function() {
       const instance = createTestInstance({
         provider: {
@@ -207,28 +193,6 @@ describe('serverless-plugin-lambda-account-access', function() {
     });
 
     describe('policy', function() {
-      it('should throw when policy principals are not configured', function() {
-        const instance = createTestInstance({
-          provider: {
-            access: {
-              groups: {
-                api: {
-                  policy: {}
-                }
-              }
-            }
-          },
-          functions: {
-            function1: {
-              allowAccess: 'api'
-            }
-          }
-        });
-
-        expect(() => instance.beforeDeploy())
-          .to.throw('Group "api" does not have policy principals configured');
-      });
-
       it('should support single principal', function() {
         const instance = createTestInstance({
           provider: {
@@ -660,54 +624,6 @@ describe('serverless-plugin-lambda-account-access', function() {
     });
 
     describe('role', function() {
-      it('should throw when role does not have name', function() {
-        const instance = createTestInstance({
-          provider: {
-            access: {
-              groups: {
-                api: {
-                  role: [{
-                    principals: 111111111111
-                  }]
-                }
-              }
-            }
-          },
-          functions: {
-            function1: {
-              allowAccess: 'api'
-            }
-          }
-        });
-
-        expect(() => instance.beforeDeploy())
-          .to.throw('Group "api" does not have role name configured');
-      });
-
-      it('should throw when role does not have principals', function() {
-        const instance = createTestInstance({
-          provider: {
-            access: {
-              groups: {
-                api: {
-                  role: [{
-                    name: 'foo'
-                  }]
-                }
-              }
-            }
-          },
-          functions: {
-            function1: {
-              allowAccess: 'api'
-            }
-          }
-        });
-
-        expect(() => instance.beforeDeploy())
-          .to.throw('Role "foo" in the "api" group does not have principals configured');
-      });
-
       it('should throw when role names are not unique', function() {
         const instance = createTestInstance({
           provider: {

--- a/test/add-permissions-tests.js
+++ b/test/add-permissions-tests.js
@@ -32,11 +32,6 @@ function createTestInstance(options) {
 describe('serverless-plugin-lambda-account-access', function() {
 
   describe('#constructor', function() {
-    it('should throw on older version', function() {
-      expect(() => createTestInstance({ version: '1.11.0' }))
-        .to.throw('serverless-plugin-lambda-account-access requires serverless 1.12 or higher!');
-    });
-
     it('should create hooks', function() {
       const instance = createTestInstance();
       expect(instance)


### PR DESCRIPTION
Closes #18 

There is no easy way to test schemas with unit tests. I checked locally on the existing project and everything seems to work.